### PR TITLE
Make figures directory relative to file

### DIFF
--- a/autoload/draw.vim
+++ b/autoload/draw.vim
@@ -1,25 +1,28 @@
-let g:im_dir = "./figures"
+let g:im_dir = "figures"
 let g:inkscape_template = "default.svg"
 
 
 function! s:Draw(im_name)
-    if !isdirectory(g:im_dir)
-	    call mkdir(g:im_dir, "p")
+    let l:im_path = expand('%:p:h'). "/". g:im_dir
+    if !isdirectory(l:im_path)
+	    call mkdir(l:im_path, "p")
     endif
 
     if filereadable(expand("~/.config/inkscape/templates/". g:inkscape_template))
-		exe ":silent !cp ~/.config/inkscape/templates/". g:inkscape_template. " ". g:im_dir. "/". a:im_name. ".svg"
+		exe ":silent !cp ~/.config/inkscape/templates/". g:inkscape_template. " ". l:im_path. "/". a:im_name. ".svg"
     else
         finish
     end
-    exe ":silent !inkscape ". g:im_dir. "/". a:im_name. ".svg"
-    exe ":silent !inkscape --export-filename=". g:im_dir. "/". a:im_name. ".png ". g:im_dir. "/". a:im_name. ".svg"
+    exe ":silent !inkscape ". l:im_path. "/". a:im_name. ".svg"
+    exe ":silent !inkscape --export-filename=". l:im_path. "/". a:im_name. ".png ". l:im_path. "/". a:im_name. ".svg"
     exe 'redraw!'
 endfunction
 
 function! draw#EditDrawing(im_name)
-    exe ":silent !inkscape ". g:im_dir. "/". a:im_name. ".svg"
-    exe ":silent !inkscape --export-filename=". g:im_dir. "/". a:im_name. ".png ". g:im_dir. "/". a:im_name. ".svg"
+    let l:im_path = expand('%:p:h'). "/". g:im_dir
+
+    exe ":silent !inkscape ". l:im_path. "/". a:im_name. ".svg"
+    exe ":silent !inkscape --export-filename=". l:im_path. "/". a:im_name. ".png ". l:im_path. "/". a:im_name. ".svg"
     exe 'redraw!'
 endfunction
 

--- a/doc/draw.txt
+++ b/doc/draw.txt
@@ -1,14 +1,17 @@
 *draw.txt*  Draw using inkscape and insert directly into document.
 
 ==============================================================================
-Mappings:
+MAPPINGS                                                       *draw-mappings*
+
 <leader>dw
     shortcut for :Draw command
 
 <leader>de
     shortcut for :EditDrawing command
 
-Commands:
+==============================================================================
+COMMANDS                                                       *draw-commands*
+
 :Draw {name}
     launch inkscape and draw figure, inserting appropriate syntax for the
     image to the document
@@ -16,9 +19,17 @@ Commands:
 :EditDrawing {name}
     edit drawing using inkscape
 
-                                                               *draw-settings*
+==============================================================================
+SETTINGS                                                       *draw-settings*
+
 Set directory and default template.
-    let g:im_dir = "./figures"
+>
+    let g:im_dir = "figures"
+<
+NOTE: The directory name should not contain any beginning or trailing `/`s
+>
     let g:inkscape_template = "default.svg"
+<
+The files can be edited in the `~/.config/inkscape/templates` directory
 
 ==============================================================================


### PR DESCRIPTION
Now when images are added, the "figures" directory will appear in the same directory as the document file.